### PR TITLE
[mz] stub out an error getting field labels for an invalid field

### DIFF
--- a/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
+++ b/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSetMetaData.java
@@ -136,9 +136,25 @@ public class PgResultSetMetaData implements ResultSetMetaData, PGResultSetMetaDa
     return connection.getTypeInfo().getDisplaySize(field.getOID(), field.getMod());
   }
 
+  static boolean HAVE_DEBUGGED_COLUMN_LABEL = false;
+
   public String getColumnLabel(int column) throws SQLException {
     Field field = getField(column);
-    return field.getColumnLabel();
+    if (field != null) {
+      return field.getColumnLabel();
+    } else {
+      System.out.printf("Got null for field at idx %s", column);
+      if (!HAVE_DEBUGGED_COLUMN_LABEL) {
+        HAVE_DEBUGGED_COLUMN_LABEL = true;
+        System.out.printf("\nDEBUGGING INVALID FIELD ACCESS in fields: ");
+          for (Field field_ :fields) {
+              System.out.printf("%s ", field_);
+          }
+        new Throwable().printStackTrace();
+      }
+      System.out.printf("\n");
+      return "field_stub_" + column;
+    }
   }
 
   public String getColumnName(int column) throws SQLException {


### PR DESCRIPTION
For some reason metabase is fetching fields at index 15-18 for the foreign-keys
sync, when the column that is being returned only has fields 13-15 set.

I'm not sure why this is happening, but since we don't have foreign keys anyway
I'm going to just stub this out with some field names that look pretty obvious
in the hope that we can debug it if/when it comes back up.

### All Submissions:

* [ ] Have you followed the guidelines in our [Contributing](https://github.com/pgjdbc/pgjdbc/blob/master/CONTRIBUTING.md) document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

1. [ ] Does your submission pass tests?
2. [ ] Does mvn checkstyle:check pass ?
3. [ ] Have you added your new test classes to an existing test suite?

### Changes to Existing Features:

* [ ] Does this break existing behaviour? If so please explain.
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your core changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
