### PR TITLE
jdbc:postgres -> jdbc:materialize

### DIFF
--- a/pgjdbc/src/main/java/io/materialize/Driver.java
+++ b/pgjdbc/src/main/java/io/materialize/Driver.java
@@ -212,7 +212,7 @@ public class Driver implements java.sql.Driver {
     // get defaults
     Properties defaults;
 
-    if (!url.startsWith("jdbc:postgresql:")) {
+    if (!url.startsWith("jdbc:materialize:")) {
       return null;
     }
     try {
@@ -554,11 +554,11 @@ public class Driver implements java.sql.Driver {
       urlArgs = url.substring(qPos + 1);
     }
 
-    if (!urlServer.startsWith("jdbc:postgresql:")) {
-      LOGGER.log(Level.FINE, "JDBC URL must start with \"jdbc:postgresql:\" but was: {0}", url);
+    if (!urlServer.startsWith("jdbc:materialize:")) {
+      LOGGER.log(Level.FINE, "JDBC URL must start with \"jdbc:materialize:\" but was: {0}", url);
       return null;
     }
-    urlServer = urlServer.substring("jdbc:postgresql:".length());
+    urlServer = urlServer.substring("jdbc:materialize:".length());
 
     if (urlServer.startsWith("//")) {
       urlServer = urlServer.substring(2);


### PR DESCRIPTION
### Background
Yesterday, I thought I wrapped up the work of cleanly connecting Metabase to Materialize by finishing the [`metabase-materialize-driver`](https://github.com/MaterializeInc/metabase-materialize-driver).

But I was wrong! I tricked myself by accidentally testing the new driver on our forked Metabase repo **with** our hacky changes. When I rolled back, the `metabase-materialize-driver` didn't work.

### The Problem
After slow debugging (and help from @quodlibetor!), we figured out that overriding the `:postgresql` protocol for our new driver was causing Metabase to try to pick up a connection from a `org.postgresql` instead of `io.materialize`. 

### The Solution
Create a new `:materialize` protocol!

I tested this locally on the [correct Metabase commit](https://github.com/MaterializeInc/metabase/commit/207e8d66151fe5e60ea4e355e012b7114aef8937) and I was able to connect to and query Materialize! 🎉 