### PR TITLE
Update getTables to only return materialized views

### DIFF
--- a/pgjdbc/src/main/java/io/materialize/jdbc/PgDatabaseMetaData.java
+++ b/pgjdbc/src/main/java/io/materialize/jdbc/PgDatabaseMetaData.java
@@ -1266,7 +1266,7 @@ public class PgDatabaseMetaData implements DatabaseMetaData {
     headers[7] = header("SELF_REFERENCING_COL_NAME");
     headers[8] = header("REF_GENERATION");
 
-    String[][] queries = {{"SHOW TABLES", "TABLE"}, {"SHOW VIEWS", "VIEW"}};
+    String[][] queries = {{"SHOW MATERIALIZED VIEWS", "MATERIALIZED VIEWS"}};
     for (String[] select_output : queries) {
       String select = select_output[0];
       String output = select_output[1];


### PR DESCRIPTION
### Background
We use this pgjdbc fork as a connector between Metabase and Materialize. Metabase uses this JDBC code to query Materialize -- both automatically and when prompted. For instance, Metabase queries Materialize automatically upon syncing in an attempt to generate dashboard queries the user might be interested in.

### The Problem
To generate suggested queries, Metabase iterates through each item returned by `getTables` and queries them in order to automatically generate potential insights. In our case, `getTables` currently returns all tables and views in Materialize. **But**, as of recently, we can only query materialized views. Since neither tables nor views are materialized, Metabase is unable to generate insights from them.

### The Solution
Only return materialized views! 

I tested this locally via Docker and it worked.