### PR TITLE
update typeAliases

### DIFF
--- a/pgjdbc/src/main/java/io/materialize/jdbc/TypeInfoCache.java
+++ b/pgjdbc/src/main/java/io/materialize/jdbc/TypeInfoCache.java
@@ -102,18 +102,28 @@ public class TypeInfoCache implements TypeInfo {
 
   static {
     typeAliases = new HashMap<String, String>();
-    typeAliases.put("smallint", "int2");
-    typeAliases.put("integer", "int4");
-    typeAliases.put("int", "int4");
-    typeAliases.put("bigint", "int8");
-    typeAliases.put("float", "float8");
     typeAliases.put("boolean", "bool");
-    typeAliases.put("decimal", "numeric");
+
+    typeAliases.put("smallint", "int2");
 
     typeAliases.put("i32", "int4");
+    typeAliases.put("integer", "int4");
+    typeAliases.put("int", "int4");
+
     typeAliases.put("i64", "int8");
+    typeAliases.put("bigint", "int8");
+
     typeAliases.put("f32", "float4");
+    typeAliases.put("real", "float4");
+
     typeAliases.put("f64", "float8");
+    typeAliases.put("double precision", "float8");
+    typeAliases.put("double", "float8");
+    typeAliases.put("float", "float8");
+
+    typeAliases.put("decimal", "numeric");
+
+    typeAliases.put("text", "varchar");
     typeAliases.put("string", "varchar");
   }
 

--- a/pgjdbc/src/main/java/io/materialize/util/StreamWrapper.java
+++ b/pgjdbc/src/main/java/io/materialize/util/StreamWrapper.java
@@ -117,7 +117,11 @@ public class StreamWrapper {
             // forcibly close it because super.finalize() may keep the FD open, which may prevent
             // file deletion
             close();
-            super.finalize();
+            try {
+              super.finalize();
+            } catch (Throwable t) {
+              throw new IOException(t);
+            }
           }
         };
       } else {


### PR DESCRIPTION
A user surfaced the following Metabase error (using our `pgjdbc` fork):
```
03-05 17:03:44 ERROR sync.util :: Error syncing Fields for Table X: Unable to find type name for double precision
("io.materialize.jdbc.TypeInfoCache.getSQLType(TypeInfoCache.java:206)"
 "io.materialize.jdbc.PgDatabaseMetaData.getColumns(PgDatabaseMetaData.java:1503)"
 "com.mchange.v2.c3p0.impl.NewProxyDatabaseMetaData.getColumns(NewProxyDatabaseMetaData.java:3140)"
 "--> driver.sql_jdbc.sync$describe_table_fields.invokeStatic(sync.clj:152)"
 "driver.sql_jdbc.sync$describe_table_fields.doInvoke(sync.clj:149)"
 "driver.sql_jdbc.sync$describe_table.invokeStatic(sync.clj:198)"
```
It turns out our `typeAliases` info didn't include all of the available aliases for [Materialize's built-in types](https://materialize.com/docs/sql/types/#built-in-types).